### PR TITLE
Add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
 __pycache__
+venv
+.venv
+tests/certs/*.cert
+tests/certs/dummy.key

--- a/tests/certs/generate_mock_certs.sh
+++ b/tests/certs/generate_mock_certs.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-001-no-valid-uzi-data.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-002-invalid-san.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = DNS:foo.bar"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-003-invalid-othername.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:msUPN;UTF8:12345678@90000111"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-004-othername-without-ia5string.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;UTF8:12345678@90000111"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-005-incorrect-san-data.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:12345678@90000111"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-006-incorrect-san-data.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:14-41-44"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-007-strict-ca-check.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.1-1-12345678-Z-90000111-01.015-00000000"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-008-invalid-version.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-2-12345678-Z-90000111-01.015-00000000"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-009-invalid-types.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-1-12345678-K-90000111-01.015-00000000"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-010-invalid-roles.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-1-12345678-N-90000111-00.015-00000000"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-011-correct.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-12345678/GN=john/CN=john doe-12345678" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-1-12345678-N-90000111-30.015-00000000"
+
+openssl req -x509 \
+    -nodes \
+    -keyout dummy.key \
+    -out mock-012-correct-admin.cert \
+    -days 3650 \
+    -subj "/C=NL/O=MockTest Cert/title=physician/SN=doe-11111111/GN=john/CN=john doe-11111111" \
+    -addext "subjectAltName = otherName:2.5.5.5;IA5STRING:2.16.528.1.1003.1.3.5.5.2-1-11111111-N-90000111-01.015-00000000"

--- a/tests/test_uzireader.py
+++ b/tests/test_uzireader.py
@@ -76,7 +76,3 @@ class TestUziReader(unittest.TestCase):
         self.assertEqual("doe-11111111", data["surName"])
         self.assertEqual("11111111", data["UziNumber"])
         self.assertEqual("1", data["UziVersion"])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_uzireader.py
+++ b/tests/test_uzireader.py
@@ -1,0 +1,81 @@
+import unittest
+import uzireader
+import os
+
+class TestUziReader(unittest.TestCase):
+
+    def setUp(self):
+        self.succ = "SUCCESS"
+        self.dir = os.path.dirname(__file__)
+
+    def readCert(self, path):
+        f = open(self.dir + "/certs/" + path, "r")
+        cert = f.read()
+        f.close()
+        return cert
+
+    def checkCert(self, path, message=None):
+        cert = self.readCert(path)
+        with self.assertRaises(uzireader.UziException, msg=message):
+            uzireader.UziPassUser(self.succ, cert)
+
+    def test_check_request_has_no_cert(self):
+        with self.assertRaises(uzireader.UziExceptionServerConfigError):
+            uzireader.UziPassUser()
+
+    def test_check_ssl_client_failed(self):
+        with self.assertRaises(uzireader.UziExceptionServerConfigError):
+            uzireader.UziPassUser()
+
+    def test_check_no_client_cert(self):
+        with self.assertRaises(uzireader.UziExceptionClientCertError):
+            uzireader.UziPassUser(self.succ)
+
+    def test_check_cert_without_valid_data(self):
+        self.checkCert("mock-001-no-valid-uzi-data.cert", "No valid UZI data found")
+
+    def test_check_cert_with_invalid_san(self):
+        self.checkCert("mock-002-invalid-san.cert", "No valid UZI data found")
+
+    def test_check_cert_with_invalid_other_name(self):
+        self.checkCert("mock-003-invalid-othername.cert", "No valid UZI data found")
+
+    def test_check_cert_without_ia5_string(self):
+        self.checkCert("mock-004-othername-without-ia5string.cert")
+
+    def test_check_cert_incorrect_san_data(self):
+        self.checkCert("mock-005-incorrect-san-data.cert", "Incorrect SAN found")
+
+    def test_check_cert_incorrect_san_data_2(self):
+        self.checkCert("mock-006-incorrect-san-data.cert", "Incorrect SAN found")
+
+    def test_check_valid_cert(self):
+        cert = self.readCert("mock-011-correct.cert")
+        data = uzireader.UziPassUser(self.succ, cert)
+
+        self.assertEqual('00000000', data["AgbCode"])
+        self.assertEqual('N', data["CardType"])
+        self.assertEqual('john', data["givenName"])
+        self.assertEqual('2.16.528.1.1003.1.3.5.5.2', data["OidCa"])
+        self.assertEqual('30.015', data["Role"])
+        self.assertEqual('90000111', data["SubscriberNumber"])
+        self.assertEqual('doe-12345678', data["surName"])
+        self.assertEqual('12345678', data["UziNumber"])
+        self.assertEqual('1', data["UziVersion"])
+
+    def test_check_valid_admin_cert(self):
+        cert = self.readCert("mock-012-correct-admin.cert")
+        data = uzireader.UziPassUser(self.succ, cert)
+
+        self.assertEqual('00000000', data["AgbCode"])
+        self.assertEqual('N', data["CardType"])
+        self.assertEqual('john', data["givenName"])
+        self.assertEqual('2.16.528.1.1003.1.3.5.5.2', data["OidCa"])
+        self.assertEqual('01.015', data["Role"])
+        self.assertEqual('90000111', data["SubscriberNumber"])
+        self.assertEqual('doe-11111111', data["surName"])
+        self.assertEqual('11111111', data["UziNumber"])
+        self.assertEqual('1', data["UziVersion"])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_uzireader.py
+++ b/tests/test_uzireader.py
@@ -2,8 +2,8 @@ import unittest
 import uzireader
 import os
 
-class TestUziReader(unittest.TestCase):
 
+class TestUziReader(unittest.TestCase):
     def setUp(self):
         self.succ = "SUCCESS"
         self.dir = os.path.dirname(__file__)
@@ -53,29 +53,30 @@ class TestUziReader(unittest.TestCase):
         cert = self.readCert("mock-011-correct.cert")
         data = uzireader.UziPassUser(self.succ, cert)
 
-        self.assertEqual('00000000', data["AgbCode"])
-        self.assertEqual('N', data["CardType"])
-        self.assertEqual('john', data["givenName"])
-        self.assertEqual('2.16.528.1.1003.1.3.5.5.2', data["OidCa"])
-        self.assertEqual('30.015', data["Role"])
-        self.assertEqual('90000111', data["SubscriberNumber"])
-        self.assertEqual('doe-12345678', data["surName"])
-        self.assertEqual('12345678', data["UziNumber"])
-        self.assertEqual('1', data["UziVersion"])
+        self.assertEqual("00000000", data["AgbCode"])
+        self.assertEqual("N", data["CardType"])
+        self.assertEqual("john", data["givenName"])
+        self.assertEqual("2.16.528.1.1003.1.3.5.5.2", data["OidCa"])
+        self.assertEqual("30.015", data["Role"])
+        self.assertEqual("90000111", data["SubscriberNumber"])
+        self.assertEqual("doe-12345678", data["surName"])
+        self.assertEqual("12345678", data["UziNumber"])
+        self.assertEqual("1", data["UziVersion"])
 
     def test_check_valid_admin_cert(self):
         cert = self.readCert("mock-012-correct-admin.cert")
         data = uzireader.UziPassUser(self.succ, cert)
 
-        self.assertEqual('00000000', data["AgbCode"])
-        self.assertEqual('N', data["CardType"])
-        self.assertEqual('john', data["givenName"])
-        self.assertEqual('2.16.528.1.1003.1.3.5.5.2', data["OidCa"])
-        self.assertEqual('01.015', data["Role"])
-        self.assertEqual('90000111', data["SubscriberNumber"])
-        self.assertEqual('doe-11111111', data["surName"])
-        self.assertEqual('11111111', data["UziNumber"])
-        self.assertEqual('1', data["UziVersion"])
+        self.assertEqual("00000000", data["AgbCode"])
+        self.assertEqual("N", data["CardType"])
+        self.assertEqual("john", data["givenName"])
+        self.assertEqual("2.16.528.1.1003.1.3.5.5.2", data["OidCa"])
+        self.assertEqual("01.015", data["Role"])
+        self.assertEqual("90000111", data["SubscriberNumber"])
+        self.assertEqual("doe-11111111", data["surName"])
+        self.assertEqual("11111111", data["UziNumber"])
+        self.assertEqual("1", data["UziVersion"])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds simple unit tests for the uzi reader ("inspired" by the php original). Also includes a script to generate mock certs from the same source. Mock certs aren't included so the script should be ran before any tests (maybe want to make a simple makefile? Or just explain this in the README)